### PR TITLE
Clean up SSH key when a server is alredy removed

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -341,10 +341,14 @@ func (d *Driver) Remove() error {
 			return errors.Wrap(err, "could not get server handle")
 		}
 
-		log.Infof(" -> Destroying server %s[%d] in...", srv.Name, srv.ID)
+		if srv == nil {
+			log.Infof(" -> Server does not exist anymore")
+		} else {
+			log.Infof(" -> Destroying server %s[%d] in...", srv.Name, srv.ID)
 
-		if _, err := d.getClient().Server.Delete(context.Background(), srv); err != nil {
-			return errors.Wrap(err, "could not delete server")
+			if _, err := d.getClient().Server.Delete(context.Background(), srv); err != nil {
+				return errors.Wrap(err, "could not delete server")
+			}
 		}
 	}
 


### PR DESCRIPTION
When a server does not exist anymore (eg if it has been removed manually
before removing it from docker-machine), gracefully handle the situation
and ensure the accompanying SSH-Key is removed aswell.

Fixes: #18