### PR TITLE
Update hcloud go to 1.13 and remove unnecessary notice

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,7 +14,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9857dce653aab290cef50f602aec3d75c6877877cbd1b163e8814465e9718771"
+  digest = "1:f1beae74e4ad389f4a6c1eaeb9539c9a0c1b7b934aee3576147b988e09184f9c"
   name = "github.com/docker/docker"
   packages = [
     "pkg/term",
@@ -44,15 +44,15 @@
   version = "v0.15.0"
 
 [[projects]]
-  digest = "1:a06b1208e37cdc6825e52b80e3d5f4b86d9b1b536c97b5b396e1e0063358a871"
+  digest = "1:11023f5bea4042c407e78c3e12266c60a05dde4c8de31281fe3d28c518fe825d"
   name = "github.com/hetznercloud/hcloud-go"
   packages = [
     "hcloud",
     "hcloud/schema",
   ]
   pruneopts = "UT"
-  revision = "2798131998b49288e9da4ecef6e38f3d665fcbb2"
-  version = "v1.10.0"
+  revision = "ecf008900c9b247d0e904c946fd092110ad07e1b"
+  version = "v1.13.0"
 
 [[projects]]
   digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/hetznercloud/hcloud-go"
-  version = "1.7.0"
+  version = "1.13.0"
 
 [[constraint]]
   name = "github.com/pkg/errors"

--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ $ docker-machine create \
 - `--hetzner-image-id`: The id of the Hetzner cloud image (or snapshot) to use, see [Images API](https://docs.hetzner.cloud/#resources-images-get) for how to get a list (mutually excludes `--hetzner-image`).
 - `--hetzner-server-type`: The type of the Hetzner Cloud server, see [Server Types API](https://docs.hetzner.cloud/#resources-server-types-get) for how to get a list (defaults to `cx11`).
 - `--hetzner-server-location`: The location to create the server in, see [Locations API](https://docs.hetzner.cloud/#resources-locations-get) for how to get a list.
-**NOTICE: Beware that Hetzner does not reject invalid location names at the time of writing this; instead, a seemingly random location is chosen. Double check both the option value's
-spelling and the newly created server to make sure the desired location was chosen indeed.**
 - `--hetzner-existing-key-path`: Use an existing (local) SSH key instead of generating a new keypair.
 - `--hetzner-existing-key-id`: **requires `--hetzner-existing-key-path`**. Use an existing (remote) SSH key instead of uploading the imported key pair,
   see [SSH Keys API](https://docs.hetzner.cloud/#resources-ssh-keys-get) for how to get a list

--- a/driver.go
+++ b/driver.go
@@ -452,7 +452,7 @@ func (d *Driver) Kill() error {
 }
 
 func (d *Driver) getClient() *hcloud.Client {
-	return hcloud.NewClient(hcloud.WithToken(d.AccessToken))
+	return hcloud.NewClient(hcloud.WithToken(d.AccessToken), hcloud.WithApplication("docker-machine-driver", Version))
 }
 
 func (d *Driver) copySSHKeyPair(src string) error {


### PR DESCRIPTION
Hello guys,

this small PR updates the underlying hcloud-go version to the latest (1.13) and it removes the notice about the location on the readme. This "error" is not the case since a long time :) 