### PR TITLE
Disable CGO to be able to run on AlpineLinux too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ go:
 env:
   global:
     - GO111MODULE=on
+    - CGO_ENABLED=0
 
 before_deploy:
   # Create binaries for many OSs and architures as tarballs.


### PR DESCRIPTION
When CGO is enabled (what is the default), the `linux_amd64`-version seems not working fine on different systems, just like Alpine Linux in my case.

A quick test to verify that:
```
/tmp # ./bin-cgo-def
ash: ./bin-cgo-def: not found

/tmp # ./bin-cgo-off
This is a Docker Machine plugin binary.
Plugin binaries are not intended to be invoked directly.
Please use this plugin through the main 'docker-machine' binary.
(API version: 1)
```
(Binaries built on Ubuntu 18.04 with Go 1.12)

File size basically stays almost the same:
```
 11700 -rwxr-xr-x    1 root     root       11.4M May 22 19:22 bin-cgo-def
 11612 -rwxr-xr-x    1 root     root       11.3M May 22 19:23 bin-cgo-off
```