### PR TITLE
feat: added option for using private network

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ $ docker-machine create \
 - `--hetzner-user-data`: Cloud-init based User data
 - `--hetzner-volumes`: Volume IDs or names which should be attached to the server
 - `--hetzner-networks`: Network IDs or names which should be attached to the server private network interface
+- `--hetzner-use-private-network`: Use private network
 
 #### Existing SSH keys
 
@@ -131,6 +132,7 @@ was used during creation.
 | `--hetzner-user-data`               | `HETZNER_USER_DATA`               | -                          |
 | `--hetzner-networks`                | `HETZNER_NETWORKS`                | -                          |
 | `--hetzner-volumes`                 | `HETZNER_VOLUMES`                 | -                          |
+| `--hetzner-use-private-network`     | `HETZNER_USE_PRIVATE_NETWORK`     | false                      |
 
 
 ## Building from source

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.12
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/docker/docker v0.0.0-20181018193557-f7e5154f37a4 // indirect
-	github.com/docker/machine v0.16.1
+	github.com/docker/machine v0.16.2
 	github.com/google/go-cmp v0.3.0 // indirect
-	github.com/hetznercloud/hcloud-go v1.14.0
+	github.com/hetznercloud/hcloud-go v1.17.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,10 +7,14 @@ github.com/docker/docker v0.0.0-20181018193557-f7e5154f37a4 h1:u7P9ul4ElF92ZjxTw
 github.com/docker/docker v0.0.0-20181018193557-f7e5154f37a4/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/machine v0.16.1 h1:zrgroZounGVkxLmBqMyc1uT2GgapXVjIWHCfBf0udrA=
 github.com/docker/machine v0.16.1/go.mod h1:I8mPNDeK1uH+JTcUU7X0ZW8KiYz0jyAgNaeSJ1rCfDI=
+github.com/docker/machine v0.16.2 h1:jyF9k3Zg+oIGxxSdYKPScyj3HqFZ6FjgA/3sblcASiU=
+github.com/docker/machine v0.16.2/go.mod h1:I8mPNDeK1uH+JTcUU7X0ZW8KiYz0jyAgNaeSJ1rCfDI=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/hetznercloud/hcloud-go v1.14.0 h1:6IdF0Vox/6j1pyEdUCbFPIzEH/K9xZZzVuSFro8Y2vw=
 github.com/hetznercloud/hcloud-go v1.14.0/go.mod h1:8lR3yHBHZWy2uGcUi9Ibt4UOoop2wrVdERJgCtxsF3Q=
+github.com/hetznercloud/hcloud-go v1.17.0 h1:IKH0GLLoTEfgMuBY+GaaVTwjYChecrHFVo4/t0sIkGU=
+github.com/hetznercloud/hcloud-go v1.17.0/go.mod h1:8lR3yHBHZWy2uGcUi9Ibt4UOoop2wrVdERJgCtxsF3Q=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=


### PR DESCRIPTION
Added option to use Hetzner private network for docker-machine communication.
Using this option in e.g. Rancher makes it possible to restrict node communication to the private network (you can disable the public network interface). See also https://github.com/mxschmitt/ui-driver-hetzner/issues/44.
