### PR TITLE
WIP: Serach for an existing key by fingerprint before attempting upload

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -241,17 +241,9 @@ func (d *Driver) Create() error {
 			return errors.Wrap(err, "could not read ssh public key")
 		}
 
-		// Try to find a key with the same Fingerprint
-		pubkey, _, _, _, err := ssh.ParseAuthorizedKey(buf)
-		if err != nil {
-			return errors.Wrap(err, "could not parse ssh public key")
-		}
-
-		fp := ssh.FingerprintLegacyMD5(pubkey)
-
-		key, _, err := d.getClient().SSHKey.GetByFingerprint(context.Background(), fp)
-		if err != nil {
-			log.Debugf("SSH key not found in Hetzner. Uploading...")
+		key, err := d.getRemoteKeyWithSameFingerprint(buf)
+		if key == nil {
+			log.Infof("SSH key not found in Hetzner. Uploading...")
 
 			keyopts := hcloud.SSHKeyCreateOpts{
 				Name:      d.GetMachineName(),
@@ -619,6 +611,21 @@ func (d *Driver) getKey() (*hcloud.SSHKey, error) {
 	}
 	d.cachedKey = stype
 	return stype, nil
+}
+
+func (d *Driver) getRemoteKeyWithSameFingerprint(pubkey_byte []byte) (*hcloud.SSHKey, error) {
+	pubkey, _, _, _, err := ssh.ParseAuthorizedKey(pubkey_byte)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse ssh public key")
+	}
+
+	fp := ssh.FingerprintLegacyMD5(pubkey)
+
+	remotekey, _, err := d.getClient().SSHKey.GetByFingerprint(context.Background(), fp)
+	if err != nil {
+		return remotekey, errors.Wrap(err, "could not get sshkey by fingerprint")
+	}
+	return remotekey, nil
 }
 
 func (d *Driver) getServerHandle() (*hcloud.Server, error) {


### PR DESCRIPTION
fixes #49

With this fix, the creation of two machines as described in #49 works. The removal is also successful:

```
am@localhost:~/go/src/github.com/am97/docker-machine-driver-hetzner$ docker-machine rm machine1
About to remove machine1
WARNING: This action will delete both local reference and remote instance.
Are you sure? (y/n): y
(machine1)  -> Destroying server machine1[7976813] in...
(machine1)  -> Destroying SSHKey am@am[2167977]...
Successfully removed machine1
am@localhost:~/go/src/github.com/am97/docker-machine-driver-hetzner$ docker-machine rm machine2
About to remove machine2
WARNING: This action will delete both local reference and remote instance.
Are you sure? (y/n): y
(machine2)  -> Destroying server machine2[7976887] in...
(machine2)  -> SSH key does not exist anymore
Successfully removed machine2
```