### PR TITLE
Add arm64 architecture for M1 based Macs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,10 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') && contains(fromJSON('["mxschmitt", "JonasProgrammer"]'), github.actor) }}
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -6,6 +6,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,5 +5,6 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
M1 Macs use the arm64 arch. Goreleaser should be able to provide a suitable binary.

Changes:
* use go 1.16 all the way (already used when building) in manual jobs and release job
* enable building arm64